### PR TITLE
Create seperate tests directory and test for axisLabels.

### DIFF
--- a/deltasigma/tests/test_axisLabels.py
+++ b/deltasigma/tests/test_axisLabels.py
@@ -1,0 +1,18 @@
+import unittest
+import numpy as np
+import deltasigma as ds
+
+class TestAxisLabels(unittest.TestCase):
+    """Test function for axisLabels()"""
+    def setUp(self):
+        self.ran = np.arange(100)
+    
+    def test_axis_label_geneation_part1(self):
+        ss = ds.axisLabels(self.ran, incr=10)
+        r = ['0', '10', '20', '30', '40', '50', '60', '70', '80', '90']
+        self.assertTrue(r == ss)
+        
+    def test_axis_label_generation_part2(self):
+        ss = ds.axisLabels(self.ran, incr=(15, 10))
+        r = ['10', '25', '40', '55', '70', '85']
+        self.assertTrue(r == ss)


### PR DESCRIPTION
First test created.  I based it off the preexisting test in _axislabels.py but changed it to use `unittest`.  I've left the original test in place for now.  This is the result I get:

```
c:\github\python-deltasigma\deltasigma (nose_setup)
λ nosetests --verbose
Vendor:  Continuum Analytics, Inc.
Package: mkl
Message: trial mode expires in 29 days
c:\github\python-deltasigma\deltasigma\_config.py:40: UserWarning: Numpy did not detect the BLAS library in the system
  warn("Numpy did not detect the BLAS library in the system")
c:\github\python-deltasigma\deltasigma\_config.py:55: UserWarning: Cannot find the path for 'cblas.h'. You may set it using the environment variable BLAS_H.
NOTE: You need to pass the path to the directories were the header files are, not the path to the files.
  warn("Cannot find the path for 'cblas.h'. You may set it using the environment variable "
test_axis_label_geneation_part1 (test_axisLabels.TestAxisLabels) ... ok
test_axis_label_generation_part2 (test_axisLabels.TestAxisLabels) ... ok

----------------------------------------------------------------------
Ran 2 tests in 0.082s

OK
```
