### PR TITLE
Update Travis to include older Python versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.5"
   - "2.6"
   - "2.7"
   - "3.2"


### PR DESCRIPTION
Added Python 2.5, 2.6, 3.2, and 3.3 to Travis, since you noted many academic labs don't update their machines often enough.  I _think_ this will work.
