### PR TITLE
Changed an `exp` to `np.exp`

### DIFF
--- a/examples/dsdemo1.ipynb
+++ b/examples/dsdemo1.ipynb
@@ -313,7 +313,7 @@
       "plot(f, magH)\n",
       "hold(True)\n",
       "G = (np.zeros((order/2,)), H[1], 1)\n",
-      "k = 1./np.abs(evalTF(G, exp(2j*np.pi*f0)))\n",
+      "k = 1./np.abs(evalTF(G, np.exp(2j*np.pi*f0)))\n",
       "G = (G[0], G[1], k)\n",
       "magG = dbv(evalTF(G, z))\n",
       "plot(f, magG, 'r')\n",


### PR DESCRIPTION
Not a problem with the import pylab, but discovered it when copying/pasting to another script.  Consistent with use of np elsewhere in notebook.  EOF LF was added by the GitHub editor
