### PR TITLE
Fixing mis-indexed slice operation in dsdemo3

### DIFF
--- a/examples/dsdemo3.ipynb
+++ b/examples/dsdemo3.ipynb
@@ -323,7 +323,7 @@
     "    maxima[:, i] = np.squeeze(xmax)\n",
     "    if any(xmax > 1e2):\n",
     "        umax = ui;\n",
-    "        u = u[:i+1];\n",
+    "        u = u[:i];\n",
     "        maxima = maxima[:, :i]\n",
     "        break;\n",
     "# save the maxima\n",


### PR DESCRIPTION
The use of `:i+1` breaks this demo if used with a higher-order modulator that has instability for an input <0.6, causing the `u` and `maxima` `ndarray` instances to be of different sizes, breaking the call to `semilogy` in the next section. Slicing by `:i` for `u` corrects this.